### PR TITLE
Add monitor check hex edits for all IIDX LDJ games (tricoro+)

### DIFF
--- a/ballerz.html
+++ b/ballerz.html
@@ -172,6 +172,19 @@
               name: 'Expert Course Force Open (in offline or local mode)',
               patches: [{offset: 0xDC953, off: [0x75], on: [0xEB]}]
             },
+            {
+                //by nibs
+                name: "Shorter monitor check",
+                tooltip: "Runs for 300 frames (5 seconds) instead of 1200 (20 seconds), recommended only if you have a very stable framerate",
+                patches: [{offset: 0x104305, off: [0xB0, 0x04], on: [0x2C, 0x01]}]
+            },
+            {
+                //by nibs
+                name: "6 digits in monitor check",
+                tooltip: "Purely visual, does not affect anything besides the FPS display",
+                //changes the FPS = %2.4f string to FPS = %2.6f
+                patches: [{offset: 0x25FD41, off: [0x34], on: [0x36]}]
+            },
           ], "2018-09-19"),
           new DllPatcher('bm2dx', [
             {

--- a/copula.html
+++ b/copula.html
@@ -10,83 +10,98 @@
         <script type="text/javascript" src="js/dllpatcher.js"></script>
         <script type="text/javascript">
             window.addEventListener("load", function() {
-                new DllPatcher("bm2dx", [
-                    {
-                     name : "Timer Freeze",
-                     patches : [{offset : 0x8F98E, off: [0x74], on : [0xEB]}]
-                    },
-                    {
-                     name : "Premium Free",
-                     patches : [{offset : 0x562BA, off: [0x75], on : [0xEB]}]
-                    },
-                    // By mon - modifies a few more bytes than needed but whatever
-                    {
-                     name : "Premium Free (2 player mode)",
-                     patches : [{offset : 0x56424, off: [0x74, 0x2f], on : [0x90, 0x90]},
-                                {offset : 0x56435, off: [0x0f, 0x85, 0x3b], on : [0xe9, 0x3c, 0xff]},
-                                {offset : 0x5643a, off: [0xff], on : [0x90]}]
-                    },
-                    {
-                     name : "Premium Free Timer Freeze",
-                     patches : [{offset : 0x4F8FD, off: [0x48], on : [0x90]}]
-                    },
-                    {
-                     name : "Unlock All Songs",
-                     patches : [{offset : 0x4FD84, off: [0x74, 0x16], on : [0x90, 0x90]}]
-                    },
-                    {
-                     name : "Level 12 Unlocked",
-                     patches : [{offset : 0x4FE35, off: [0x83, 0xFF, 0x02, 0x74, 0x0B, 0x83, 0xFF, 0x05, 0x74, 0x06, 0xB0, 0x01],
-                                                   on : [0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90]}]
-                    },
-                    {
-                     name : "Cursor lock",
-                     tooltip : "After song finishes, song select remains on previous song",
-                     patches : [{offset : 0x63722, off: [0x74, 0x23], on : [0x90, 0x90]}]
-                    },
-                    {
-                     name : "CS-Style Song Start Delay",
-                     tooltip : "Holding Start will pause the song at the beginning until you release it",
-                     patches : [{offset : 0x6F3FF, off: [0x7C], on : [0xEB]}]
-                    },
-                    {
-                     name : "Disable HCN Tutorial",
-                     tooltip : "Don't show tutorial for Hell Charge Notes",
-                     patches : [{offset : 0x6F3E6, off: [0x5E, 0xE9, 0x24, 0xFF, 0xFF, 0xFF], on : [0x00, 0x00, 0x00, 0x00, 0x00, 0x00]}]
-                    },
-                    {
-                     name : "Quick Retry",
-                     tooltip : "Hold VEFX and Effect during a song to restart",
-                     patches : [{offset : 0x46724, off: [0x8A, 0xC3], on : [0xB0, 0x01]}]
-                    },
-                    {
-                     name : "Dark Mode",
-                     patches : [{offset : 0x68833, off: [0x74, 0x32], on : [0x90, 0x90]}]
-                    },
-                    {
-                     name : "Volume Bug Fix",
-                     tooltip : "If your volume gets forced to max, turn this on",
-                     patches : [{offset : 0xCB2B9, off: [0x00], on : [0x01]}]
-                    },
-                    {
-                     type : "union",
-                     name : "FREE PLAY text",
-                     offset : 0x1379A,
-                     patches : [
-                         {
-                          name : "On",
-                          patch : [0x88, 0x3D, 0x11, 0x10],
-                         },
-                         {
-                          name : "Off",
-                          patch : [0x87, 0x3D, 0x11, 0x10],
-                         },
-                         {
-                          name : "Replace with song name",
-                          patch : [0x54, 0x1D, 0x42, 0x11],
-                         },
-                     ]
-                    },
+                new DllPatcherContainer([
+                    new DllPatcher("bm2dx", [
+                        {
+                         name : "Timer Freeze",
+                         patches : [{offset : 0x8F98E, off: [0x74], on : [0xEB]}]
+                        },
+                        {
+                         name : "Premium Free",
+                         patches : [{offset : 0x562BA, off: [0x75], on : [0xEB]}]
+                        },
+                        // By mon - modifies a few more bytes than needed but whatever
+                        {
+                         name : "Premium Free (2 player mode)",
+                         patches : [{offset : 0x56424, off: [0x74, 0x2f], on : [0x90, 0x90]},
+                                    {offset : 0x56435, off: [0x0f, 0x85, 0x3b], on : [0xe9, 0x3c, 0xff]},
+                                    {offset : 0x5643a, off: [0xff], on : [0x90]}]
+                        },
+                        {
+                         name : "Premium Free Timer Freeze",
+                         patches : [{offset : 0x4F8FD, off: [0x48], on : [0x90]}]
+                        },
+                        {
+                         name : "Unlock All Songs",
+                         patches : [{offset : 0x4FD84, off: [0x74, 0x16], on : [0x90, 0x90]}]
+                        },
+                        {
+                         name : "Level 12 Unlocked",
+                         patches : [{offset : 0x4FE35, off: [0x83, 0xFF, 0x02, 0x74, 0x0B, 0x83, 0xFF, 0x05, 0x74, 0x06, 0xB0, 0x01],
+                                                       on : [0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90]}]
+                        },
+                        {
+                         name : "Cursor lock",
+                         tooltip : "After song finishes, song select remains on previous song",
+                         patches : [{offset : 0x63722, off: [0x74, 0x23], on : [0x90, 0x90]}]
+                        },
+                        {
+                         name : "CS-Style Song Start Delay",
+                         tooltip : "Holding Start will pause the song at the beginning until you release it",
+                         patches : [{offset : 0x6F3FF, off: [0x7C], on : [0xEB]}]
+                        },
+                        {
+                         name : "Disable HCN Tutorial",
+                         tooltip : "Don't show tutorial for Hell Charge Notes",
+                         patches : [{offset : 0x6F3E6, off: [0x5E, 0xE9, 0x24, 0xFF, 0xFF, 0xFF], on : [0x00, 0x00, 0x00, 0x00, 0x00, 0x00]}]
+                        },
+                        {
+                         name : "Quick Retry",
+                         tooltip : "Hold VEFX and Effect during a song to restart",
+                         patches : [{offset : 0x46724, off: [0x8A, 0xC3], on : [0xB0, 0x01]}]
+                        },
+                        {
+                         name : "Dark Mode",
+                         patches : [{offset : 0x68833, off: [0x74, 0x32], on : [0x90, 0x90]}]
+                        },
+                        {
+                         name : "Volume Bug Fix",
+                         tooltip : "If your volume gets forced to max, turn this on",
+                         patches : [{offset : 0xCB2B9, off: [0x00], on : [0x01]}]
+                        },
+                        {
+                         type : "union",
+                         name : "FREE PLAY text",
+                         offset : 0x1379A,
+                         patches : [
+                             {
+                              name : "On",
+                              patch : [0x88, 0x3D, 0x11, 0x10],
+                             },
+                             {
+                              name : "Off",
+                              patch : [0x87, 0x3D, 0x11, 0x10],
+                             },
+                             {
+                              name : "Replace with song name",
+                              patch : [0x54, 0x1D, 0x42, 0x11],
+                             },
+                         ]
+                        },
+                        {
+                            //by nibs
+                            name: "Shorter monitor check",
+                            tooltip: "Runs for 300 frames (5 seconds) instead of 1200 (20 seconds), recommended only if you have a very stable framerate",
+                            patches: [{offset: 0x77DAA, off: [0xB0, 0x04], on: [0x2C, 0x01]}]
+                        },
+                        {
+                            //by nibs
+                            name: "6 digits in monitor check",
+                            tooltip: "Purely visual, does not affect anything besides the FPS display",
+                            //changes the FPS = %2.4f string to FPS = %2.6f
+                            patches: [{offset: 0x13E429, off: [0x34], on: [0x36]}]
+                        },
+                    ], "2016-08-31"),
                 ]);
             });
         </script>

--- a/pendual.html
+++ b/pendual.html
@@ -10,42 +10,72 @@
         <script type="text/javascript" src="js/dllpatcher.js"></script>
         <script type="text/javascript">
             window.addEventListener("load", function() {
-                new DllPatcher("bm2dx", [
-                    {
-                     name : "Timer Freeze",
-                     patches : [{offset : 0x9c55e, off: [0x74], on : [0xEB]}]
-                    },
-                    {
-                     name : "Premium Free",
-                     patches : [{offset : 0x5d31b, off: [0x75], on : [0xEB]}]
-                    },
-                    {
-                     name : "Premium Free Timer Freeze",
-                     patches : [{offset : 0x563ad, off: [0x48], on : [0x90]}]
-                    },
-                    {
-                     name : "Unlock All Songs",
-                     patches : [{offset : 0x58b3e, off: [0x74, 0x0a], on : [0x90, 0x90]}]
-                    },
-                    {
-                     name : "CS-Style Song Start Delay",
-                     tooltip : "Holding Start will pause the song at the beginning until you release it",
-                     patches : [{offset : 0x77cf6, off: [0x7C], on : [0xEB]}]
-                    },
-                    {
-                     name : "Cursor lock",
-                     tooltip : "After song finishes, song select remains on previous song",
-                     patches : [{offset : 0x6BF3A, off: [0x74, 0x23], on : [0x90, 0x90]}]
-                    },
-                    {
-                     name : "Volume Bug Fix",
-                     tooltip : "If your volume gets forced to max, turn this on",
-                     patches : [{offset : 0xD5D09, off: [0x00], on : [0x01]}]
-                    },
-                    {
-                     name : "Replace FREE PLAY text with song name",
-                     patches : [{offset : 0x14C3A, off: [0x90, 0x3F, 0x12, 0x10], on : [0x24, 0xAA, 0x43, 0x11]}]
-                    },
+                new DllPatcherContainer([
+                    new DllPatcher("bm2dx", [
+                        {
+                            //by nibs
+                            name: "Shorter monitor check",
+                            tooltip: "Runs for 300 frames (5 seconds) instead of 1200 (20 seconds), recommended only if you have a very stable framerate",
+                            patches: [{offset: 0x6D5EA, off: [0xB0, 0x04], on: [0x2C, 0x01]}]
+                        },
+                        {
+                            //by nibs
+                            name: "6 digits in monitor check",
+                            tooltip: "Purely visual, does not affect anything besides the FPS display",
+                            //changes the FPS = %2.4f string to FPS = %2.6f
+                            patches: [{offset: 0x14E2AD, off: [0x34], on: [0x36]}]
+                        },
+                    ], "2014-09-17"),
+                    new DllPatcher("bm2dx", [
+                        {
+                            name: "Timer Freeze",
+                            patches: [{offset: 0x9c55e, off: [0x74], on: [0xEB]}]
+                        },
+                        {
+                            name: "Premium Free",
+                            patches: [{offset: 0x5d31b, off: [0x75], on: [0xEB]}]
+                        },
+                        {
+                            name: "Premium Free Timer Freeze",
+                            patches: [{offset: 0x563ad, off: [0x48], on: [0x90]}]
+                        },
+                        {
+                            name: "Unlock All Songs",
+                            patches: [{offset: 0x58b3e, off: [0x75, 0x0a], on: [0x90, 0x90]}]
+                        },
+                        {
+                            name: "CS-Style Song Start Delay",
+                            tooltip: "Holding Start will pause the song at the beginning until you release it",
+                            patches: [{offset: 0x77cf6, off: [0x7C], on: [0xEB]}]
+                        },
+                        {
+                            name: "Cursor lock",
+                            tooltip: "After song finishes, song select remains on previous song",
+                            patches: [{offset: 0x6BF3A, off: [0x74, 0x23], on: [0x90, 0x90]}]
+                        },
+                        {
+                            name: "Volume Bug Fix",
+                            tooltip: "If your volume gets forced to max, turn this on",
+                            patches: [{offset: 0xD5D09, off: [0x00], on: [0x01]}]
+                        },
+                        {
+                            name: "Replace FREE PLAY text with song name",
+                            patches: [{offset: 0x14C3A, off: [0x90, 0x3F, 0x12, 0x10], on: [0x24, 0xAA, 0x43, 0x11]}]
+                        },
+                        {
+                            //by nibs
+                            name: "Shorter monitor check",
+                            tooltip: "Runs for 300 frames (5 seconds) instead of 1200 (20 seconds), recommended only if you have a very stable framerate",
+                            patches: [{offset: 0x8065A, off: [0xB0, 0x04], on: [0x2C, 0x01]}]
+                        },
+                        {
+                            //by nibs
+                            name: "6 digits in monitor check",
+                            tooltip: "Purely visual, does not affect anything besides the FPS display",
+                            //changes the FPS = %2.4f string to FPS = %2.6f
+                            patches: [{offset: 0x16E911, off: [0x34], on: [0x36]}]
+                        },
+                    ], "2015-08-05"),
                 ]);
             });
         </script>

--- a/sinobuz.html
+++ b/sinobuz.html
@@ -101,83 +101,20 @@
                          tooltip : "Hold VEFX and Effect during a song to restart",
                          patches : [{offset : 0x4e284, off: [0x8A, 0xC3], on : [0xB0, 0x01]}]
                         },
-                    ], "stock"),
-
-                    new DllPatcher("bm2dx_omni", [
                         {
-                         name : "Timer Freeze",
-                         patches : [{offset : 0x9BCFE, off: [0x74], on : [0xEB]}]
+                            //by nibs
+                            name: "Shorter monitor check",
+                            tooltip: "Runs for 300 frames (5 seconds) instead of 1200 (20 seconds), recommended only if you have a very stable framerate",
+                            patches: [{offset: 0x81A5A, off: [0xB0, 0x04], on: [0x2C, 0x01]}]
                         },
                         {
-                         name : "Premium Free",
-                         patches : [{offset : 0x60B9B, off: [0x75], on : [0xEB]}]
+                            //by nibs
+                            name: "6 digits in monitor check",
+                            tooltip: "Purely visual, does not affect anything besides the FPS display",
+                            //changes the FPS = %2.4f string to FPS = %2.6f
+                            patches: [{offset: 0x15ADF9, off: [0x34], on: [0x36]}]
                         },
-                        {
-                         name : "Premium Free (2 player mode)",
-                         patches : [{offset : 0x60D14, off: [0x74, 0x2f], on : [0x90, 0x90]},
-                                    {offset : 0x60D25, off: [0x0f, 0x85, 0x3b], on : [0xe9, 0x3c, 0xff]},
-                                    {offset : 0x60D2A, off: [0xff], on : [0x90]}]
-                        },
-                        {
-                         name : "Premium Free Timer Freeze",
-                         patches : [{offset : 0x5DFFD, off: [0x48], on : [0x90]}]
-                        },
-                        {
-                         name : "Unlock All Songs",
-                         patches : [{offset : 0x5C125, off: [0x74, 0x15], on : [0x90, 0x90]}]
-                        },
-                        {
-                         name : "Cursor lock",
-                         tooltip : "After song finishes, song select remains on previous song",
-                         patches : [{offset : 0x6CAE5, off: [0x74, 0x23], on : [0x90, 0x90]}]
-                        },
-                        {
-                         name : "CS-Style Song Start Delay",
-                         tooltip : "Holding Start will pause the song at the beginning until you release it",
-                         patches : [{offset : 0x78EE2, off: [0x7C], on : [0xEB]}]
-                        },
-                        {
-                         name : "Dark Mode",
-                         patches : [{offset : 0x71E57, off: [0x74, 0x3b], on : [0x90, 0x90]}]
-                        },
-                        {
-                         name : "Disable Bar Lines",
-                         patches : [{offset : 0x3d450, off: [0x75], on : [0xEB]}]
-                        },
-                        {
-                         name : "Remove Rainbow Banners",
-                         patches : [{offset : 0x12C355, off: [0x5F], on : [0x00]}]
-                        },
-                        {
-                         name : "Volume Bug Fix",
-                         tooltip : "If your volume gets forced to max, turn this on",
-                         patches : [{offset : 0xDA219, off: [0x00], on : [0x01]}]
-                        },
-                        {
-                         name : "Free play text to LED ticker",
-                         patches : [{offset : 0x150EA, off: [0xE0, 0x8F, 0x12, 0x10], on : [0x64, 0x99, 0x6A, 0x11]}]
-                        },
-                        {
-                         name : "Free play text to LED ticker (Upper left)",
-                         patches : [{offset : 0xA4865, off: [0x74, 0x32], on : [0x90, 0x90]},
-                                    {offset : 0xA4880, off: [0x8c, 0x1D, 0x16, 0x10], on : [0x64, 0x99, 0x6A, 0x11]}]
-                        },
-                        {
-                         name : "Debug mode (disables score saving!)",
-                         tooltip : "Press F1 in-game to open menu",
-                         patches : [{offset : 0xa2ef0, off: [0x32, 0xC0], on : [0x0C, 0x01]}]
-                        },
-                        {
-                         name : "Skip Card Entry",
-                         tooltip : "Useful for those without service or to prevent login",
-                         patches : [{offset : 0x64014, off: [0x32], on : [0x20]}]
-                        },
-                        {
-                         name : "Quick Retry",
-                         tooltip : "Hold VEFX and Effect during a song to restart",
-                         patches : [{offset : 0x4e154, off: [0x8A, 0xC3], on : [0xB0, 0x01]}]
-                        },
-                    ], "omnimix")
+                    ], "2017-08-28"),
                 ]);
             });
         </script>

--- a/spada.html
+++ b/spada.html
@@ -13,6 +13,21 @@
             new DllPatcherContainer([
                 new DllPatcher("bm2dx", [
                     {
+                        //by nibs
+                        name: "Shorter monitor check",
+                        tooltip: "Runs for 300 frames (5 seconds) instead of 1200 (20 seconds), recommended only if you have a very stable framerate",
+                        patches: [{offset: 0x6B4AA, off: [0xB0, 0x04], on: [0x2C, 0x01]}]
+                    },
+                    {
+                        //by nibs
+                        name: "6 digits in monitor check",
+                        tooltip: "Purely visual, does not affect anything besides the FPS display",
+                        //changes the FPS = %2.4f string to FPS = %2.6f
+                        patches: [{offset: 0x160B05, off: [0x34], on: [0x36]}]
+                    },
+                ], "2013-10-02"),
+                new DllPatcher("bm2dx", [
+                    {
                         name: "Timer Freeze",
                         patches: [{offset: 0x9150E, off: [0x74], on: [0xEB]}]
                     },
@@ -55,6 +70,19 @@
                     {
                         name: "Free play text to LED ticker",
                         patches: [{offset: 0x13E8A, off: [0xEC, 0x0B, 0x15, 0x10], on: [0xF4, 0xAE, 0x41, 0x11]}]
+                    },
+                    {
+                        //by nibs
+                        name: "Shorter monitor check",
+                        tooltip: "Runs for 300 frames (5 seconds) instead of 1200 (20 seconds), recommended only if you have a very stable framerate",
+                        patches: [{offset: 0x721BA, off: [0xB0, 0x04], on: [0x2C, 0x01]}]
+                    },
+                    {
+                        //by nibs
+                        name: "6 digits in monitor check",
+                        tooltip: "Purely visual, does not affect anything besides the FPS display",
+                        //changes the FPS = %2.4f string to FPS = %2.6f
+                        patches: [{offset: 0x192175, off: [0x34], on: [0x36]}]
                     },
                 ], "2014-07-16"),
             ]);

--- a/tricoro.html
+++ b/tricoro.html
@@ -13,6 +13,21 @@
             new DllPatcherContainer([
                 new DllPatcher("bm2dx", [
                     {
+                        //by nibs
+                        name: "Shorter monitor check",
+                        tooltip: "Runs for 300 frames (5 seconds) instead of 1200 (20 seconds), recommended only if you have a very stable framerate",
+                        patches: [{offset: 0x66C0D, off: [0xB0, 0x04], on: [0x2C, 0x01]}]
+                    },
+                    {
+                        //by nibs
+                        name: "6 digits in monitor check",
+                        tooltip: "Purely visual, does not affect anything besides the FPS display",
+                        //changes the FPS = %2.4f string to FPS = %2.6f
+                        patches: [{offset: 0x143C45, off: [0x34], on: [0x36]}]
+                    },
+                ], "2012-09-19"),
+                new DllPatcher("bm2dx", [
+                    {
                         name: "Premium Free",
                         patches: [{offset: 0x49CAC, off: [0x75], on: [0xEB]}]
                     },
@@ -37,6 +52,19 @@
                     {
                         name: "Unlock All Songs",
                         patches: [{offset: 0x4921D, off: [0x75, 0x09], on: [0x90, 0x90]}]
+                    },
+                    {
+                        //by nibs
+                        name: "Shorter monitor check",
+                        tooltip: "Runs for 300 frames (5 seconds) instead of 1200 (20 seconds), recommended only if you have a very stable framerate",
+                        patches: [{offset: 0x6D07A, off: [0xB0, 0x04], on: [0x2C, 0x01]}]
+                    },
+                    {
+                        //by nibs
+                        name: "6 digits in monitor check",
+                        tooltip: "Purely visual, does not affect anything besides the FPS display",
+                        //changes the FPS = %2.4f string to FPS = %2.6f
+                        patches: [{offset: 0x16BDD5, off: [0x34], on: [0x36]}]
                     },
                 ], "2013-09-09"),
             ]);


### PR DESCRIPTION
Run monitor check for 300 frames instead of 1200, and show 6 digits in monitor check instead of 4