### PR TITLE
Add hex edit to skip the decide screen.

### DIFF
--- a/ballerz.html
+++ b/ballerz.html
@@ -185,6 +185,12 @@
                 //changes the FPS = %2.4f string to FPS = %2.6f
                 patches: [{offset: 0x25FD41, off: [0x34], on: [0x36]}]
             },
+            {
+              // by aixxe
+              name: 'Skip decide screen',
+              tooltip : "Immediately loads into chart after selection.",
+              patches: [{offset: 0x72775, off: [0xE8, 0x66, 0x00, 0x00, 0x00], on: [0x90, 0x90, 0x90, 0x90, 0x90]}]
+            },
           ], "2018-09-19"),
           new DllPatcher('bm2dx', [
             {


### PR DESCRIPTION
Here's something I randomly found while messing around with INFINITAS.

This hex edit skips the screen in-between selecting a chart and the fade-in, loading directly into the chart instead, saving you a whole 2~ seconds! _(might be more in some games)_

https://streamable.com/gsy68

It should work on any LDJ game but this patch is just for the latest IIDX 25 library.