### PR TITLE
Adjust name capitalization/formatting

### DIFF
--- a/ballerz.html
+++ b/ballerz.html
@@ -2,7 +2,7 @@
 <html lang='en'>
 <head>
     <meta charset='utf-8'>
-    <title>IIDX Cannon Ballers DLL Modder</title>
+    <title>IIDX CANNON BALLERS DLL Modder</title>
     <link rel='stylesheet' href='css/style.css'>
     <!-- don't hate -->
     <script src='https://code.jquery.com/jquery-3.3.1.slim.min.js'></script>
@@ -245,6 +245,6 @@
     </script>
 </head>
 <body>
-<h1>IIDX Cannon Ballers DLL Modder</h1>
+<h1>IIDX CANNON BALLERS DLL Modder</h1>
 </body>
 </html>

--- a/beatstream1.html
+++ b/beatstream1.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>BeatStream 1 DLL Modder</title>
+        <title>BeatStream DLL Modder</title>
         <link rel="stylesheet" href="css/style.css">
         <!-- don't hate -->
         <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
@@ -31,6 +31,6 @@
         </script>
     </head>
     <body>
-        <h1>BeatStream 1 DLL Modder</h1>
+        <h1>BeatStream DLL Modder</h1>
     </body>
 </html>

--- a/beatstream2.html
+++ b/beatstream2.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>BeatStream 2 DLL Modder</title>
+        <title>BeatStream アニムトライヴ DLL Modder</title>
         <link rel="stylesheet" href="css/style.css">
         <!-- don't hate -->
         <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
@@ -39,6 +39,6 @@
         </script>
     </head>
     <body>
-        <h1>BeatStream 2 アニムトライヴ DLL Modder</h1>
+        <h1>BeatStream アニムトライヴ DLL Modder</h1>
     </body>
 </html>

--- a/copula.html
+++ b/copula.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>IIDX Copula DLL Modder</title>
+        <title>IIDX copula DLL Modder</title>
         <link rel="stylesheet" href="css/style.css">
         <!-- don't hate -->
         <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
@@ -107,6 +107,6 @@
         </script>
     </head>
     <body>
-        <h1>IIDX Copula DLL Modder</h1>
+        <h1>IIDX copula DLL Modder</h1>
     </body>
 </html>

--- a/gfdmv5.html
+++ b/gfdmv5.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>GuitarFreaks & DrumMania V5 Rock to Infinity DLL Modder</title>
+    <title>GFDM V5 Rock to Infinity DLL Modder</title>
     <link rel="stylesheet" href="css/style.css">
     <!-- don't hate -->
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
@@ -49,6 +49,6 @@
     </script>
 </head>
 <body>
-    <h1>GuitarFreaks & DrumMania V5 Rock to Infinity DLL Modder</h1>
+    <h1>GFDM V5 Rock to Infinity DLL Modder</h1>
 </body>
 </html>

--- a/gfdmv6.html
+++ b/gfdmv6.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>GuitarFreaks & DrumMania V5 Rock to Infinity DLL Modder</title>
+    <title>GFDM V5 BLAZING!!!! DLL Modder</title>
     <link rel="stylesheet" href="css/style.css">
     <!-- don't hate -->
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
@@ -42,6 +42,6 @@
     </script>
 </head>
 <body>
-    <h1>GuitarFreaks & DrumMania V6 BLAZING!!!! DLL Modder</h1>
+    <h1>GFDM V6 BLAZING!!!! DLL Modder</h1>
 </body>
 </html>

--- a/gfdmv7.html
+++ b/gfdmv7.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>GuitarFreaks & DrumMania V5 Rock to Infinity DLL Modder</title>
+    <title>GFDM V7 DLL Modder</title>
     <link rel="stylesheet" href="css/style.css">
     <!-- don't hate -->
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
@@ -48,6 +48,6 @@
     </script>
 </head>
 <body>
-    <h1>GuitarFreaks & DrumMania V7 DLL Modder</h1>
+    <h1>GFDM V7 DLL Modder</h1>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>Bemani DLL Patching Tools</title>
+        <title>BEMANI DLL Patching Tools</title>
         <link rel="stylesheet" href="css/style.css">
     </head>
     <body>
@@ -10,39 +10,39 @@
         <div class="icons">
             <a href="beatstream1.html" class="gameicon"><div>
                 <img src="img/beatstream.png">
-                <div>BeatStream 1</div>
+                <div>BeatStream</div>
             </div></a>
             <a href="beatstream2.html" class="gameicon"><div>
                 <img src="img/beatstream2.png">
-                <div>BeatStream 2</div>
+                <div>BeatStream<br>アニムトライヴ</div>
             </div></a>
             <a href="tricoro.html" class="gameicon"><div>
                 <img src="img/tricoro.png">
-                <div>Beatmania IIDX 20 Tricoro</div>
+                <div>beatmania IIDX 20 tricoro</div>
             </div></a>
             <a href="spada.html" class="gameicon"><div>
                 <img src="img/spada.png">
-                <div>Beatmania IIDX 21 Spada</div>
+                <div>beatmania IIDX 21 SPADA</div>
             </div></a>
             <a href="pendual.html" class="gameicon"><div>
                 <img src="img/pendual.png">
-                <div>Beatmania IIDX 22 Pendual</div>
+                <div>beatmania IIDX 22 PENDUAL</div>
             </div></a>
             <a href="copula.html" class="gameicon"><div>
                 <img src="img/copula.png">
-                <div>Beatmania IIDX 23 Copula</div>
+                <div>beatmania IIDX 23 copula</div>
             </div></a>
             <a href="sinobuz.html" class="gameicon"><div>
                 <img src="img/sinobuz.png">
-                <div>Beatmania IIDX 24 Sinobuz</div>
+                <div>beatmania IIDX 24 SINOBUZ</div>
             </div></a>
             <a href="ballerz.html" class="gameicon"><div>
                 <img src="img/ballerz.png">
-                <div>Beatmania IIDX 25 Cannon Ballers</div>
+                <div>beatmania IIDX 25 CANNON BALLERS</div>
             </div></a>
-	    <a href="rootage.html" class="gameicon"><div>
+			<a href="rootage.html" class="gameicon"><div>
                 <img src="img/rootage.png">
-                <div>Beatmania IIDX 26 Rootage</div>
+                <div>beatmania IIDX 26 Rootage</div>
             </div></a>
             <a href="ddr2014.html" class="gameicon"><div>
                 <img src="img/ddr2014.png">
@@ -70,19 +70,19 @@
             </div></a>
             <a href="jubeatprop.html" class="gameicon"><div>
                 <img src="img/prop.png">
-                <div>Jubeat Prop</div>
+                <div>jubeat prop</div>
             </div></a>
             <a href="jubeatqubell.html" class="gameicon"><div>
                 <img src="img/qubell.png">
-                <div>Jubeat Qubell</div>
+                <div>jubeat Qubell</div>
             </div></a>
             <a href="jubeatclan.html" class="gameicon"><div>
                 <img src="img/clan.png">
-                <div>Jubeat Clan</div>
+                <div>jubeat clan</div>
             </div></a>
             <a href="museca1.html" class="gameicon"><div>
                 <img src="img/museca1.png">
-                <div>Museca 1</div>
+                <div>MÚSECA</div>
             </div></a>
             <a href="museca2.html" class="gameicon"><div>
                 <img src="img/museca2.png">
@@ -90,15 +90,15 @@
             </div></a>
             <a href="popn22lapistoria.html" class="gameicon"><div>
                 <img src="img/lapis.png">
-                <div>Pop'n Music 22 Lapistoria</div>
+                <div>pop'n music 22 Lapistoria</div>
             </div></a>
             <a href="popn23eclale.html" class="gameicon"><div>
                 <img src="img/eclale.png">
-                <div>Pop'n Music 23 éclale</div>
+                <div>pop'n music 23 éclale</div>
             </div></a>
             <a href="popn24usaneko.html" class="gameicon"><div>
                 <img src="img/usaneko.png">
-                <div>Pop'n Music 24 うさぎと猫と少年の夢</div>
+                <div>pop'n music 24 うさぎと猫と少年の夢</div>
             </div></a>
             <a href="reflecbeat-groovin-upper.html" class="gameicon"><div>
                 <img src="img/groovin.png">

--- a/jubeatqubell.html
+++ b/jubeatqubell.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>jubeat qubell DLL Modder</title>
+        <title>jubeat Qubell DLL Modder</title>
         <link rel="stylesheet" href="css/style.css">
         <!-- don't hate -->
         <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
@@ -33,6 +33,6 @@
         </script>
     </head>
     <body>
-        <h1>jubeat qubell DLL Modder</h1>
+        <h1>jubeat Qubell DLL Modder</h1>
     </body>
 </html>

--- a/museca1.html
+++ b/museca1.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>Museca 1 DLL Modder</title>
+        <title>MÚSECA DLL Modder</title>
         <link rel="stylesheet" href="css/style.css">
         <!-- don't hate -->
         <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
@@ -24,6 +24,6 @@
         </script>
     </head>
     <body>
-        <h1>Museca 1 DLL Modder</h1>
+        <h1>MÚSECA DLL Modder</h1>
     </body>
 </html>

--- a/pendual.html
+++ b/pendual.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>IIDX Pendual DLL Modder</title>
+        <title>IIDX PENDUAL DLL Modder</title>
         <link rel="stylesheet" href="css/style.css">
         <!-- don't hate -->
         <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
@@ -81,6 +81,6 @@
         </script>
     </head>
     <body>
-        <h1>IIDX Pendual DLL Modder</h1>
+        <h1>IIDX PENDUAL DLL Modder</h1>
     </body>
 </html>

--- a/sinobuz.html
+++ b/sinobuz.html
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <title>IIDX Sinobuz DLL Modder</title>
+        <title>IIDX SINOBUZ DLL Modder</title>
         <link rel="stylesheet" href="css/style.css">
         <!-- don't hate -->
         <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"></script>
@@ -120,6 +120,6 @@
         </script>
     </head>
     <body>
-        <h1>IIDX Sinobuz DLL Modder</h1>
+        <h1>IIDX SINOBUZ DLL Modder</h1>
     </body>
 </html>


### PR DESCRIPTION
Sinobuz->SINOBUZ, Jubeat->jubeat etc

Removed numbers from games that didn't have them (museca, BST)

Also fixed a mistake with the GFDM pages, they all had the V5 title

BST AnimTribe has a line break on the index page so the name doesn't wrap weirdly (or whatever the word is)

without break: ![image](https://user-images.githubusercontent.com/23622616/58447790-994e2180-80d3-11e9-812f-430a1c2c783d.png)

with break: ![image](https://user-images.githubusercontent.com/23622616/58447811-abc85b00-80d3-11e9-9aa4-9a9c13a2aba5.png)

