### PR TITLE
Changed last byte to nop in museca2

### DIFF
--- a/museca2.html
+++ b/museca2.html
@@ -33,8 +33,8 @@
                             },
                             {
                                 offset: 0x17E065,
-                                off: [0x00, 0xC3],
-                                on: [0xC3, 0xCC]
+                                off: [0x00],
+                                on: [0x90]
                             }
                         ]
                     },
@@ -76,8 +76,8 @@
                             },
                             {
                                 offset: 0x17E425,
-                                off: [0x00, 0xC3],
-                                on: [0xC3, 0xCC]
+                                off: [0x00],
+                                on: [0x90]
                             }
                         ]
                     },


### PR DESCRIPTION
I thought that maybe changing the last byte to a nop was better than actually having to shift the return to the left. Sorry for the double PR