### PR TITLE
Chuni: Set All Timers to 999

### DIFF
--- a/chuniamazon.html
+++ b/chuniamazon.html
@@ -66,6 +66,13 @@
                             {offset: 0x6FFC62, off: [0x74], on: [0xEB]},
                         ],
                     },
+                    {
+                        // esterTion
+                        name: "Set All Timers to 999",
+                        patches: [
+                            {offset: 0x5C30E0, off: [0x8B, 0x44, 0x24, 0x04, 0x69, 0xC0, 0xE8, 0x03, 0x00, 0x00], on: [0xB8, 0x58, 0x3E, 0x0F, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90]},
+                        ],
+                    },
                 ]);
             });
         </script>


### PR DESCRIPTION
Originally I was trying to patch function at 0x9C44A0 (set up timer seconds? ) and 0x9C41F0 (set up timer infinite display), but turns out it's just a display, the actual timer is still there. 
Then I found there's this "convient" multiply function, which takes second value and turns it into milliseconds? 
Patched it to always return 999000, and it actually works. 

Chose this value because: 
1. Chunithm timer can't hold larger than 1000 seconds.
2. Some timer (e.g. mode selection, map selection, ticket selection) adds 900 milliseconds to that value. When the timer value is over 1000 seconds, the game will actually play the "time up" sound once (because it reached 0). 

![QQ图片20200311024106 png](https://user-images.githubusercontent.com/7265411/76347567-d2ddd980-6341-11ea-9de1-e95773d98a82.jpg)
