### PR TITLE
Add force enable headphones for SDVX IV & SDVX V.

### DIFF
--- a/sdvx4.html
+++ b/sdvx4.html
@@ -143,6 +143,15 @@
               tooltip: 'Automatically skips the screen between song select and gameplay',
               patches: [{offset: 0x315600, off: [0x4D], on: [0x4E]}]
             },
+            {
+              // created by aixxe
+              name: 'Force Enable Headphones',
+              tooltip: 'Overrides headphone detection to always be enabled. Useful for cabinets.',
+              patches: [
+                {offset: 0x20B418, off: [0x74, 0x05], on: [0x90, 0x90]},
+                {offset: 0x20B41F, off: [0x89, 0x5E, 0x48], on: [0x90, 0x90, 0x90]},
+              ]
+            },
           ]),
           new Patcher('soundvoltex.dll', "2018-10-23", [
             {

--- a/sdvx5.html
+++ b/sdvx5.html
@@ -297,6 +297,14 @@
               tooltip: 'Useful to play with Omega Dimension Ex-Track',
               patches: [{offset: 0x406C94, off: [0xFF, 0xCA], on: [0x90, 0x90]}]
             },
+            {
+              // created by aixxe
+              name: 'Force Enable Headphones',
+              tooltip: 'Overrides headphone detection to always be enabled. Useful for cabinets.',
+              patches: [
+                {offset: 0x618978, off: [0x89, 0x8B, 0x90, 0x00, 0x00, 0x00, 0x84, 0xC9, 0x74, 0x08], on: [0xC7, 0x83, 0x90, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]},
+              ]
+            },
             // created by Xyen
             {
               name: 'Infinite Premium Time',


### PR DESCRIPTION
Hex edit for making the game think headphones are always plugged in.

Mainly designed for cabinets where plugging in headphones doesn't trigger the detection.