### PR TITLE
feat(op2): Add new UI text patches

### DIFF
--- a/js/dllpatcher.js
+++ b/js/dllpatcher.js
@@ -205,13 +205,7 @@ class PatchContainer {
     getSupportedVersions() {
         var descriptions = [];
         for (var i = 0; i < this.patchers.length; i++) {
-            // Concat description if it is an array of datecodes, push if it is
-            // just a string
-            if (typeof this.patchers[i].description === 'object') {
-                descriptions = descriptions.concat(this.patchers[i].description);
-            } else {
-                descriptions.push(this.patchers[i].description);
-            }
+            descriptions.push(this.patchers[i].description);
         }
         return descriptions;
     }

--- a/js/dllpatcher.js
+++ b/js/dllpatcher.js
@@ -205,7 +205,13 @@ class PatchContainer {
     getSupportedVersions() {
         var descriptions = [];
         for (var i = 0; i < this.patchers.length; i++) {
-            descriptions.push(this.patchers[i].description);
+            // Concat description if it is an array of datecodes, push if it is
+            // just a string
+            if (typeof this.patchers[i].description === 'object') {
+                descriptions = descriptions.concat(this.patchers[i].description);
+            } else {
+                descriptions.push(this.patchers[i].description);
+            }
         }
         return descriptions;
     }

--- a/nostalgiaop2.html
+++ b/nostalgiaop2.html
@@ -12,7 +12,7 @@
       window.addEventListener('load', function () {
         new PatchContainer([
           // Patches found by Arm1stice
-          new Patcher('nostalgia.dll', ["2019-11-27", "2019-10-02"], [
+          new Patcher('nostalgia.dll', "2019-10-02 / 2019-11-27", [
             {
               name: 'Menu Timer Freeze',
               patches: [{offset: 0x303D33, off: [0x41, 0xFF, 0xC8], on: [0x90, 0x90, 0x90]}]

--- a/nostalgiaop2.html
+++ b/nostalgiaop2.html
@@ -12,7 +12,7 @@
       window.addEventListener('load', function () {
         new PatchContainer([
           // Patches found by Arm1stice
-          new Patcher('nostalgia.dll', "2019-10-02 / 2019-11-27", [
+          new Patcher('nostalgia.dll', "2019-10-02, 2019-11-27", [
             {
               name: 'Menu Timer Freeze',
               patches: [{offset: 0x303D33, off: [0x41, 0xFF, 0xC8], on: [0x90, 0x90, 0x90]}]

--- a/nostalgiaop2.html
+++ b/nostalgiaop2.html
@@ -12,7 +12,7 @@
       window.addEventListener('load', function () {
         new PatchContainer([
           // Patches found by Arm1stice
-          new Patcher('nostalgia.dll', "2019-11-27", [
+          new Patcher('nostalgia.dll', ["2019-11-27", "2019-10-02"], [
             {
               name: 'Menu Timer Freeze',
               patches: [{offset: 0x303D33, off: [0x41, 0xFF, 0xC8], on: [0x90, 0x90, 0x90]}]
@@ -21,19 +21,27 @@
               name: 'Shorter Monitor Check',
               tooltip : "Similar to Rootage, recommended only if you have a stable framerate",
               patches: [{offset: 0x21A6FA, off: [0x1E], on: [0x00]}]
+            },
+            {
+              name: 'Hide "EXTRA PASELI: %d"',
+              patches: [
+                {offset: 0x307BD2, off: [0xCA, 0x2F, 0x2A], on: [0x04, 0x72, 0x26]},
+                {offset: 0x307BEE, off: [0x7E, 0x2F, 0x2A], on: [0xE8, 0x71, 0x26]}
+              ]
+            },
+            {
+              name: 'Hide "PASELI: *****"',
+              patches: [{offset: 0x307A6E, off: [0xFF, 0x15, 0x14, 0x42, 0x09, 0x00], on: [0xE9, 0xAD, 0x01, 0x00, 0x00, 0x90]}]
+            },
+            {
+              name: 'Hide Credit Count',
+              tooltip : 'Hides "CREDIT: %d" and "CREDIT %d  COIN: %d / %d"',
+              patches: [
+                {offset: 0x307E31, off: [0xBB, 0x2B, 0x2A], on: [0xA5, 0x6F, 0x26]},
+                {offset: 0x307E4D, off: [0x7F, 0x2B, 0x2A], on: [0x89, 0x6F, 0x26]}
+              ]
             },
           ]),
-          new Patcher('nostalgia.dll', "2019-10-02", [
-            {
-              name: 'Menu Timer Freeze',
-              patches: [{offset: 0x303D33, off: [0x41, 0xFF, 0xC8], on: [0x90, 0x90, 0x90]}]
-            },
-            {
-              name: 'Shorter Monitor Check',
-              tooltip : "Similar to Rootage, recommended only if you have a stable framerate",
-              patches: [{offset: 0x21A6FA, off: [0x1E], on: [0x00]}]
-            },
-          ])
         ]);
       });
     </script>


### PR DESCRIPTION
This PR adds new patches for Op.2 that hide some of the text from the UI. It also includes an update to dllpatcher.js to allow an array of date codes to be used to describe an instance of `Patcher`. This provides the ability to visibly show support for multiple date codes that share the exact same patches. Otherwise, if you duplicate an instance of `Patcher` with the same patches, two patching windows get created because both will match the provided DLL file. If you do not think that supporting arrays is the correct way to go about this, then another alternative is to simply break out of the patch matching loop as soon as it has found a match, rather than continuing through the rest of the list.