### PR TITLE
Chunithm Amazon: Increase max credits to 254

### DIFF
--- a/chuniamazon.html
+++ b/chuniamazon.html
@@ -94,9 +94,9 @@
                     {
                         // esterTion
                         name: "Free Play",
-                        tooltip: "Increase credit counter when consuming",
+                        tooltip: "Endless credits",
                         patches: [
-                            {offset: 0xBF6595, off: [0x28], on: [0x00]},
+                            {offset: 0xBF6595, off: [0x28], on: [0x08]},
                         ],
                     },
                 ]),
@@ -181,9 +181,9 @@
                     {
                         // esterTion
                         name: "Free Play",
-                        tooltip: "Increase credit counter when consuming",
+                        tooltip: "Endless credits",
                         patches: [
-                            {offset: 0xBC4F55, off: [0x28], on: [0x00]},
+                            {offset: 0xBC4F55, off: [0x28], on: [0x08]},
                         ],
                     },
                 ])

--- a/chuniamazon.html
+++ b/chuniamazon.html
@@ -90,7 +90,15 @@
                         patches: [
                             {offset: 0xBF6177, off: [0x8A, 0x5D, 0x14], on: [0xB3, 0xFE, 0x90]},
                         ],
-                    }
+                    },
+                    {
+                        // esterTion
+                        name: "Free Play",
+                        tooltip: "Increase credit counter when consuming",
+                        patches: [
+                            {offset: 0xBF6595, off: [0x28], on: [0x00]},
+                        ],
+                    },
                 ]),
                 new Patcher("chuniApp.exe", "(1.30.00) AMAZON", [
                     {
@@ -169,7 +177,15 @@
                         patches: [
                             {offset: 0xBC4B37, off: [0x8A, 0x5D, 0x14], on: [0xB3, 0xFE, 0x90]},
                         ],
-                    }
+                    },
+                    {
+                        // esterTion
+                        name: "Free Play",
+                        tooltip: "Increase credit counter when consuming",
+                        patches: [
+                            {offset: 0xBC4F55, off: [0x28], on: [0x00]},
+                        ],
+                    },
                 ])
             ]);
             });

--- a/chuniamazon.html
+++ b/chuniamazon.html
@@ -83,6 +83,13 @@
                         patches: [
                             {offset: 0x44CBA3, off: [0x01], on: [0x00]},
                         ]
+                    },
+                    {
+                        // esterTion
+                        name: "Increase max credits to 254",
+                        patches: [
+                            {offset: 0xBF6177, off: [0x8A, 0x5D, 0x14], on: [0xB3, 0xFE, 0x90]},
+                        ],
                     }
                 ]),
                 new Patcher("chuniApp.exe", "(1.30.00) AMAZON", [
@@ -155,6 +162,13 @@
                         patches: [
                             {offset: 0x440CD3, off: [0x01], on: [0x00]},
                         ]
+                    },
+                    {
+                        // esterTion
+                        name: "Increase max credits to 254",
+                        patches: [
+                            {offset: 0xBC4B37, off: [0x8A, 0x5D, 0x14], on: [0xB3, 0xFE, 0x90]},
+                        ],
                     }
                 ])
             ]);


### PR DESCRIPTION
This is a weird patch

I actually tried 255 (0xFF), and the credit counter rolled back to 0 without stopping, which is somehow extremely funny to me