### PR TITLE
Show successful match, fix text/button reset

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -209,6 +209,12 @@ button:hover:enabled, .fileLabel > strong:hover {
     color: red;
 }
 
+.matchSuccess {
+    font-size: 15px;
+    font-style: italic;
+    color: green;
+}
+
 li > button {
     height: 24px;
     padding: 0 7px;

--- a/js/dllpatcher.js
+++ b/js/dllpatcher.js
@@ -211,6 +211,7 @@ class PatchContainer {
         var supportedDlls = $("<ul>");
         this.forceLoadTexts = [];
         this.forceLoadButtons = [];
+        this.matchSuccessText = [];
         for (var i = 0; i < this.patchers.length; i++) {
             var checkboxId = createID();
 
@@ -223,6 +224,9 @@ class PatchContainer {
             var matchPercent = $('<span>').addClass('matchPercent');
             this.forceLoadTexts.push(matchPercent);
             matchPercent.appendTo(listItem);
+            var matchSuccess = $('<span>').addClass('matchSuccess');
+            this.matchSuccessText.push(matchSuccess);
+            matchSuccess.appendTo(listItem);
             var forceButton = $('<button>').text('Force load?').hide();
             this.forceLoadButtons.push(forceButton);
             forceButton.appendTo(listItem);
@@ -300,6 +304,10 @@ class PatchContainer {
             self.errorDiv.empty();
             self.successDiv.empty();
             for (var i = 0; i < self.patchers.length; i++) {
+                // reset text and buttons
+                self.forceLoadButtons[i].hide();
+                self.forceLoadTexts[i].text('');
+                self.matchSuccessText[i].text('');
                 var patcher = self.patchers[i];
                 // remove the previous UI to clear the page
                 patcher.destroyUI();
@@ -310,6 +318,10 @@ class PatchContainer {
                 if (patcher.validatePatches()) {
                     found = true;
                     loadPatch(this, self, patcher);
+                    // show patches matched for 100% - helps identify which version is loaded
+                    var valid = patcher.validPatches;
+                    var percent = (valid / patcher.totalPatches * 100).toFixed(1);
+                    self.matchSuccessText[i].text(' ' + valid + ' of ' + patcher.totalPatches + ' patches matched (' + percent + '%) ');
                 }
             }
 

--- a/js/dllpatcher.js
+++ b/js/dllpatcher.js
@@ -320,8 +320,7 @@ class PatchContainer {
                     loadPatch(this, self, patcher);
                     // show patches matched for 100% - helps identify which version is loaded
                     var valid = patcher.validPatches;
-                    var percent = (valid / patcher.totalPatches * 100).toFixed(1);
-                    self.matchSuccessText[i].text(' ' + valid + ' of ' + patcher.totalPatches + ' patches matched (' + percent + '%) ');
+                    self.matchSuccessText[i].text(' ' + valid + ' of ' + valid + ' patches matched (100%) ');
                 }
             }
 


### PR DESCRIPTION
Shows patches matched for full matches to help identify which version was uploaded (with accompanying green style).

![image](https://user-images.githubusercontent.com/34446199/112621769-5d776680-8de7-11eb-8fe4-db5d0068ed18.png)

Also, fixes force load text and buttons not hiding/clearing when uploading a matching file after a non-matching file without reloading the page.

Example from live version (fixed in this commit):
![image](https://user-images.githubusercontent.com/34446199/112621948-93b4e600-8de7-11eb-9d99-d0193730ec23.png)
