### PR TITLE
Add volume fix for Heroic Verse TDJ

### DIFF
--- a/heroicverse.html
+++ b/heroicverse.html
@@ -241,8 +241,8 @@
               ]
             },
             {
-              name: 'Louder audio on TDJ',
-              tooltip : "Significantly increase the volume for TDJ.",
+              name: 'Increase game volume',
+              tooltip : "Ignore the in-game volume settings and use the maximum possible volume level. Especially helpful for TDJ which tends to be very quiet.",
               patches: [
                 {offset: 0x63F2E5, off: [0xFF, 0x90, 0x98, 0x00, 0x00, 0x00], on:[0x90, 0x90, 0x90, 0x90, 0x90, 0x90]},
               ]

--- a/heroicverse.html
+++ b/heroicverse.html
@@ -239,6 +239,13 @@
               patches: [
                 {offset: 0x88D1C0, off: [0x10], on:[0x00]},
               ]
+            },
+            {
+              name: 'Louder audio on TDJ',
+              tooltip : "Significantly increase the volume for TDJ.",
+              patches: [
+                {offset: 0x63F2E5, off: [0xFF, 0x90, 0x98, 0x00, 0x00, 0x00], on:[0x90, 0x90, 0x90, 0x90, 0x90, 0x90]},
+              ]
             }
           ]),
         ]);


### PR DESCRIPTION
The patch removes volume limiter that gets applied when the game starts. LDJ will be slightly louder, TDJ will be significantly louder. As a small side effect the volume settings in TDJ test menu will be ignored.