### PR TITLE
BISTROVER: more patches for 0915

### DIFF
--- a/bistrover.html
+++ b/bistrover.html
@@ -209,6 +209,113 @@
                         ],
                     },
                     {
+                        name: "Force 120hz timing and adapter mode in LDJ (Experimental)",
+                        patches: [
+                            { offset: 0x45F163, off: [0x75], on: [0xeb] },
+                            { offset: 0x854A2E, off: [0x3c], on: [0x78] },
+                            { offset: 0x854C19, off: [0x74, 0x03], on: [0x90, 0x90] },
+                        ],
+                    },
+                    {
+                        name: "WASAPI Shared Mode (with 44100Hz)",
+                        patches: [{ offset: 0x28C9A1, off: [0x01], on: [0x00] }],
+                    },
+                    {
+                        name: "Unscramble touch screen keypad in TDJ",
+                        patches: [
+                            {
+                                offset: 0x7FB125,
+                                off: [0x4d, 0x03, 0xc8, 0x49, 0xf7, 0xf1],
+                                on: [0xba, 0x0c, 0x00, 0x00, 0x00, 0x90],
+                            },
+                        ],
+                    },
+                    {
+                        name: "1P Premium Free",
+                        tooltip: "Forcibly enables Premium Free option for 1P",
+                        patches: [
+                            { offset: 0x6FAD09, off: [0x75], on: [0xEB] },
+                        ],
+                    },
+                    {
+                        name: "2P Premium Free",
+                        tooltip: "Forcibly enables Premium Free option for 2P",
+                        patches: [
+                            { offset: 0x6FAF0A, off: [0x74, 0x6C], on: [0x90, 0x90] },
+                            { offset: 0x6FAF20, off: [0x74, 0x56], on: [0x90, 0x90] },
+                        ],
+                    },
+                    {
+                        name: "2P force ARENA",
+                        tooltip: "Allows selecting Arena option on 2P side",
+                        patches: [
+                            { offset: 0x6FAF35, off: [0x75, 0x41], on: [0x90, 0x90] },
+                        ],
+                    },
+                    {
+                        name: "Force BPL BATTLE",
+                        tooltip: "Forcibly enables BPL BATTLE option",
+                        patches: [
+                            { offset: 0x6FAF5A, off: [0x74, 0x1C], on: [0x90, 0x90] },
+                        ],
+                    },
+                    {
+                        name: "Skip Decide Screen",
+                        patches: [
+                            {
+                                offset: 0x3CD7C0,
+                                off: [0xe8, 0x6b, 0x00, 0x00, 0x00],
+                                on: [0x90, 0x90, 0x90, 0x90, 0x90],
+                            },
+                        ],
+                    },
+                    {
+                        name: "CS-style song start delay",
+                        tooltip : "Holding Start will pause the song at the beginning until you release it",
+                        patches: [
+                            {
+                                offset: 0x72DF33,
+                                off: [0x7d, 0x4d],
+                                on: [0x90, 0x90],
+                            },
+                        ],
+                    },
+                    {
+                        name: "Cursor Lock",
+                        patches: [
+                            { offset: 0x7026EF, off: [0x74, 0x1f], on: [0x90, 0x90] },
+                        ],
+                    },
+                    {
+                        name: "Quick Retry",
+                        patches: [
+                            { offset: 0x4A859F, off: [0x32, 0xC0], on: [0xB0, 0x01] },
+                        ],
+                    },
+                    {
+                        name: "Always show FAST/SLOW total",
+                        patches: [
+                            { offset: 0x7186C3, off: [0x74], on: [0x75] },
+                            { offset: 0x7188E0, off: [0x74], on: [0x75] },
+                        ],
+                    },
+                    {
+                        name: "Force max V-Discs",
+                        tooltip : "Allows for infinite Leggendaria plays in Premium Free",
+                        patches:
+                            {
+                                offset: 0x4B20F9,
+                                off: [0x44, 0x89, 0x4C, 0x81, 0x08, 0xC3, 0xCC, 0x48, 0x89, 0x5C, 0x24, 0x08],
+                                on: [0xC7, 0x44, 0x81, 0x08, 0x10, 0x00, 0x00, 0x00, 0x90, 0x90, 0x90, 0x90],
+                            },
+                    },
+                    {
+                        name: "Hide time limit display on results screen",
+                        patches: [
+                            { offset: 0x73576F, off: [0x84, 0xC0], on: [0x90, 0x90] },
+                        ],
+                    },
+                    {
                         name: "Premium Free Timer Freeze",
                         tooltip:
                             "Freezes the timer in PREMIUM FREE mode, allowing unlimited play until exit",
@@ -223,6 +330,39 @@
                     {
                         name: "Standard/Menu Timer Freeze",
                         patches: [{ offset: 0x77A5B7, off: [0x74], on: [0xEB] }],
+                    },
+                    {
+                        name: "Hide bottom text",
+                        tooltip: "Hides the CREDIT, INSERT COINS, NO ACCOUNT, NOT AVAILABLE, and EXTRA PASELI messages",
+                        patches: [
+                            { offset: 0x3B2591, off: [0x7F, 0x12, 0x44, 0x8B, 0xCB, 0x4C, 0x8D, 0x05, 0xEB, 0xB1, 0x6C, 0x00], on: [0x90, 0xE9, 0x22, 0x00, 0x00, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90] }, //EXTRA PASELI: %d
+                            { offset: 0x3B294D, off: [0xE8, 0x5E, 0xB1, 0x00, 0x00], on: [0x90, 0x90, 0x90, 0x90, 0x90] }, //INSERT COIN[S]
+                            { offset: 0x3B2839, off: [0xFF, 0x15, 0xA9, 0x3B, 0x6C, 0x00], on: [0x90, 0x90, 0x90, 0x90, 0x90, 0x90] }, //PASELI: NO ACCOUNT
+                            { offset: 0x3B26B4, off: [0x48, 0x8D, 0x05, 0xFD, 0x1A, 0x90, 0x04], on: [0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90] }, //PASELI: NOT AVAILABLE
+                            { offset: 0x3B24B6, off: [0xFF, 0x15, 0x2C, 0x3F, 0x6C, 0x00], on: [0x90, 0x90, 0x90, 0x90, 0x90, 0x90] }, //CREDIT: %d
+                        ],
+                    },
+                    {
+                        name: "Also hide \"PASELI: ******\" message",
+                        tooltip: "Disable if using PASELI display to LED ticker patch",
+                        patches: [
+                            { offset: 0x3B279B, off: [0xFF, 0x15, 0x47, 0x3C, 0x6C, 0x00], on: [0x90, 0x90, 0x90, 0x90, 0x90, 0x90] }, //PASELI: ******
+                        ],
+                    },
+                    {
+                        name: "Redirect LED ticker to FREE PLAY",
+                        tooltip: "Displays LED ticker messages on bottom right when FREE PLAY is enabled",
+                        patches: [
+                            { offset: 0x3B264F, off: [0xDD, 0xB0, 0x6C, 0x00], on: [0x99, 0x83, 0x19, 0x05] }, //PASELI: ******
+                        ],
+                    },
+                    {
+                        name: "Redirect LED ticker to PASELI display",
+                        tooltip: "Displays LED ticker messages on bottom left when PASELI messages are present",
+                        patches: [
+                            { offset: 0x3B2768, off: [0x4C, 0xB0, 0x6C, 0x00], on: [0x80, 0x82, 0x19, 0x05] }, //PASELI: %d
+                            { offset: 0x3B278D, off: [0x47, 0xB0, 0x6C, 0x00], on: [0x5B, 0x82, 0x19, 0x05] }, //PASELI: ******
+                        ],
                     },
                 ]),
             ]);


### PR DESCRIPTION
hopefully I actually formatted it decently [and didn't typo] this time?

Currently the hide bottom text patch is now split between two patches to allow the choice of enabling LED ticker display without having freeplay on, since freeplay locks out the 4-song selection for BPL BATTLE.