### PR TITLE
BISTROVER: probably fixed v-disc patch not displaying as intended

### DIFF
--- a/bistrover.html
+++ b/bistrover.html
@@ -302,12 +302,13 @@
                     {
                         name: "Force max V-Discs",
                         tooltip : "Allows for infinite Leggendaria plays in Premium Free",
-                        patches:
+                        patches: [
                             {
                                 offset: 0x4B20F9,
                                 off: [0x44, 0x89, 0x4C, 0x81, 0x08, 0xC3, 0xCC, 0x48, 0x89, 0x5C, 0x24, 0x08],
                                 on: [0xC7, 0x44, 0x81, 0x08, 0x10, 0x00, 0x00, 0x00, 0x90, 0x90, 0x90, 0x90],
                             },
+                        ],
                     },
                     {
                         name: "Hide time limit display on results screen",


### PR DESCRIPTION
gfdi square brackets