### PR TITLE
Add "Disable Recording Lock" hex edit for IIDX RESIDENT

### DIFF
--- a/resident.html
+++ b/resident.html
@@ -772,6 +772,14 @@
                             { offset: 0x5917CD, off: [0xE8, 0x3E, 0x18, 0x03, 0x00], on: [0xB8, 0x01, 0x00, 0x00, 0x00] },
                         ]
                     },
+                    {
+                        name: "Disable Recording Lock",
+                        tooltip: "Allows all songs to be recorded in-game",
+                        patches: [
+                            { offset: 0x5973A8, off: [0x75], on: [0xEB] },
+                            { offset: 0x59740D, off: [0x32, 0xC0], on: [0xF6, 0xD0] },
+                        ]
+                    },
                 ]),
                 new Patcher("bm2dx.dll", "2023-09-05 (LDJ-012)", [
                     {


### PR DESCRIPTION
Allows 'locked' songs (mostly licenses) to be recorded using the in-game subscreen thing

Alternative method to editing the flags in `video_music_list.xml`