### PR TITLE
Fix recording lock crash on networks without Videos support

### DIFF
--- a/bistrover.html
+++ b/bistrover.html
@@ -1209,10 +1209,7 @@
                     {
                         name: "Disable Recording Lock",
                         tooltip: "Allows all songs to be recorded in-game",
-                        patches: [
-                            { offset: 0x5739E8, off: [0x75], on: [0xEB] },
-                            { offset: 0x573A4D, off: [0x32, 0xC0], on: [0xF6, 0xD0] },
-                        ]
+                        patches: [{ offset: 0x573A1F, off: [0x40, 0x84, 0xFF], on: [0x90, 0x90, 0x90] }],
                     },
                     {
                         // https://github.com/spice2x/spice2x.github.io/issues/102

--- a/casthour.html
+++ b/casthour.html
@@ -3796,10 +3796,7 @@
                     {
                         name: "Disable Recording Lock",
                         tooltip: "Allows all songs to be recorded in-game",
-                        patches: [
-                            { offset: 0x4669D8, off: [0x75], on: [0xEB] },
-                            { offset: 0x466A3D, off: [0x32, 0xC0], on: [0xF6, 0xD0] },
-                        ]
+                        patches: [{ offset: 0x466A0F, off: [0x40, 0x84, 0xFF], on: [0x90, 0x90, 0x90] }],
                     },
                     {
                         // https://github.com/spice2x/spice2x.github.io/issues/102

--- a/resident.html
+++ b/resident.html
@@ -775,10 +775,7 @@
                     {
                         name: "Disable Recording Lock",
                         tooltip: "Allows all songs to be recorded in-game",
-                        patches: [
-                            { offset: 0x5973A8, off: [0x75], on: [0xEB] },
-                            { offset: 0x59740D, off: [0x32, 0xC0], on: [0xF6, 0xD0] },
-                        ]
+                        patches: [{ offset: 0x5973DF, off: [0x40, 0x84, 0xFF], on: [0x90, 0x90, 0x90] }],
                     },
                 ]),
                 new Patcher("bm2dx.dll", "2023-09-05 (LDJ-012)", [


### PR DESCRIPTION
Fix for https://github.com/mon/BemaniPatcher/pull/342#issuecomment-1984898583, only alters the check _after_ recording is known to be supported and the player has accepted the T&Cs

Users of the previous edit will need to either revert the changes manually or re-apply from a clean DLL

Would definitely appreciate if you could test this new version out, @drmext