### PR TITLE
[chunithm] Add amdaemon patches for free play/local server usage

### DIFF
--- a/chusansun.html
+++ b/chusansun.html
@@ -117,6 +117,28 @@
                 new PatchContainer([
                 new Patcher("amdaemon.exe", "2.10.00", [
                     {
+                        name: "Allow 127.0.0.1/localhost as the network server",
+                        patches: [
+                            {
+                                offset: 0x3B6EF4,
+                                off: [0xFF, 0x15, 0x3E, 0x79, 0x1A, 0x00, 0x8B],
+                                on: [0x33, 0xC0, 0x48, 0x83, 0xC4, 0x28, 0xC3],
+                            },
+                            {
+                                offset: 0x6BC83C,
+                                off: [0x31, 0x32, 0x37, 0x2F],
+                                on: [0x30, 0x2F, 0x38, 0x00],
+                            },
+                        ],
+                    },
+                    {
+                        name: "Free Play",
+                        tooltip: "Endless credits",
+                        patches: [
+                            {offset: 0x2BB928, off: [0x28], on: [0x08]},
+                        ]
+                    },
+                    {
                         name: "Replace error 6401 with no error",
                         danger: "[DEPRECATED] Sets all instances of error 6401 to 0",
                         patches: [

--- a/chusansun.html
+++ b/chusansun.html
@@ -1,120 +1,121 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>CHUNITHM SUN Modder</title>
-        <link rel="stylesheet" href="css/style.css">
-        <script type="text/javascript" src="js/dllpatcher.js"></script>
-        <script type="text/javascript">
-            window.addEventListener("load", function () {
+
+<head>
+    <meta charset="utf-8">
+    <title>CHUNITHM SUN Modder</title>
+    <link rel="stylesheet" href="css/style.css">
+    <script type="text/javascript" src="js/dllpatcher.js"></script>
+    <script type="text/javascript">
+        window.addEventListener("load", function () {
             new PatchContainer([
                 new Patcher("chusanApp.exe", "2.10.00", [
                     {
                         name: "Disable shop close lockout",
                         tooltip: "Disables ~12-8am lockout. Does not disable maint lockout from 6:30-7am JST",
                         patches: [
-                            {offset: 0xBAB8F3, off: [0x74], on: [0xEB]},
+                            { offset: 0xBAB8F3, off: [0x74], on: [0xEB] },
                         ],
                     },
                     {
                         name: "Force shared audio mode, system audio samplerate must be 48000",
                         tooltip: "Improves compatibility but may increase latency",
                         patches: [
-                            {offset: 0xEC8F7A, off: [0x01], on: [0x00]},
+                            { offset: 0xEC8F7A, off: [0x01], on: [0x00] },
                         ],
                     },
                     {
                         name: "Force 2 channel audio output",
                         patches: [
-                            {offset: 0xEC9051, off: [0x75, 0x3F], on: [0x90, 0x90]},
+                            { offset: 0xEC9051, off: [0x75, 0x3F], on: [0x90, 0x90] },
                         ],
                     },
                     {
                         name: "Disable Song Select Timer",
                         patches: [
-                            {offset: 0x9ADF1B, off: [0x74], on: [0xEB]},
+                            { offset: 0x9ADF1B, off: [0x74], on: [0xEB] },
                         ],
                     },
                     {
                         name: "Set All Timers to 999",
                         patches: [
-                            {offset: 0x8393D0, off: [0x8B, 0x44, 0x24, 0x04, 0x69, 0xC0, 0xE8, 0x03, 0x00, 0x00], on: [0xB8, 0x58, 0x3E, 0x0F, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90]},
+                            { offset: 0x8393D0, off: [0x8B, 0x44, 0x24, 0x04, 0x69, 0xC0, 0xE8, 0x03, 0x00, 0x00], on: [0xB8, 0x58, 0x3E, 0x0F, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90] },
                         ],
                     },
                     {
                         name: "Patch for head-to-head play",
                         tooltip: "Fix infinite sync while trying to connect to head to head play.",
                         patches: [
-                            {offset: 0x6218F3, off: [0x01], on: [0x00]},
+                            { offset: 0x6218F3, off: [0x01], on: [0x00] },
                         ]
                     },
                     {
                         name: "No Encryption",
                         tooltip: "Title server workaround",
                         patches: [
-                            {offset: 0x1D55C40, off: [0xD2], on: [0x00]},
-                            {offset: 0x1D55C44, off: [0xD2], on: [0x00]},
+                            { offset: 0x1D55C40, off: [0xD2], on: [0x00] },
+                            { offset: 0x1D55C44, off: [0xD2], on: [0x00] },
                         ]
                     },
                     {
                         name: "Unlimit Maximum Tracks",
                         tooltip: "You must check to play more than 7 tracks.",
                         patches: [
-                            {offset: 0x6E84E7, off: [0xF0], on: [0xC0]},
+                            { offset: 0x6E84E7, off: [0xF0], on: [0xC0] },
                         ],
                     },
                     {
-                        type : "number",
-                        name : "Max Tracks (Up to 12)",
-                        offset : 0x3978C1,
-                        size : 4,
-                        min : 1,
-                        max : 12,
+                        type: "number",
+                        name: "Max Tracks (Up to 12)",
+                        offset: 0x3978C1,
+                        size: 4,
+                        min: 1,
+                        max: 12,
                     },
                     {
                         name: "Ignore some errors from amdaemon",
                         danger: "[DEPRECATED] May relieve some errors like error 6401, but may also cause problems elsewhere.",
                         patches: [
-                            {offset: 0x37D4AB, off: [0x75], on: [0xEB]},
+                            { offset: 0x37D4AB, off: [0x75], on: [0xEB] },
                         ],
                     },
                     {
                         name: "CVT Mode",
                         danger: "[DEPRECATED] Check to use 60Hz",
                         patches: [
-                            {offset: 0x1CD04, off: [0x01], on: [0x00]},
-                            {offset: 0x1CD3B, off: [0x01], on: [0x00]},
+                            { offset: 0x1CD04, off: [0x01], on: [0x00] },
+                            { offset: 0x1CD3B, off: [0x01], on: [0x00] },
 
-                            {offset: 0x37B07B, off: [0x75], on: [0xEB]},
-                            {offset: 0x37CBBE, off: [0x84, 0xC0, 0x0F, 0x94, 0xC1], on: [0x90, 0x90, 0x90, 0x90, 0x90]},
-                            {offset: 0xEAC007, off: [0x80], on: [0x00]},
+                            { offset: 0x37B07B, off: [0x75], on: [0xEB] },
+                            { offset: 0x37CBBE, off: [0x84, 0xC0, 0x0F, 0x94, 0xC1], on: [0x90, 0x90, 0x90, 0x90, 0x90] },
+                            { offset: 0xEAC007, off: [0x80], on: [0x00] },
                         ],
                     },
                     {
                         name: "Disable 1080p check",
-						danger: "[DEPRECATED]",
+                        danger: "[DEPRECATED]",
                         patches: [
-                            {offset: 0x1CCBF, off: [0x81, 0xBC, 0x24, 0xB8, 0x02, 0x00, 0x00, 0x80, 0x07, 0x00, 0x00, 0x75, 0x1F, 0x81, 0xBC, 0x24, 0xBC, 0x02, 0x00, 0x00, 0x38, 0x04, 0x00, 0x00, 0x75, 0x12], on: [0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90]},
+                            { offset: 0x1CCBF, off: [0x81, 0xBC, 0x24, 0xB8, 0x02, 0x00, 0x00, 0x80, 0x07, 0x00, 0x00, 0x75, 0x1F, 0x81, 0xBC, 0x24, 0xBC, 0x02, 0x00, 0x00, 0x38, 0x04, 0x00, 0x00, 0x75, 0x12], on: [0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90] },
                         ],
                     },
                     {
                         name: "Bypass LED board check",
                         danger: "[DEPRECATED] Forces LED board check to good and auto continues",
                         patches: [
-                            {offset: 0x98004A, off: [0x01], on: [0x00]},
-                            {offset: 0x98004F, off: [0x00], on: [0x01]},
+                            { offset: 0x98004A, off: [0x01], on: [0x00] },
+                            { offset: 0x98004F, off: [0x00], on: [0x01] },
                         ]
                     },
                     {
                         name: "Force 120hz check",
                         danger: "[DEPRECATED] Check to make the 120hz check pass always (don't use this with the CVT Mode patch)",
                         patches: [
-                            {offset: 0x1CCB1, off: [0x85, 0xC0], on: [0xEB, 0x30]},
+                            { offset: 0x1CCB1, off: [0x85, 0xC0], on: [0xEB, 0x30] },
                         ],
                     },
                 ])
-                ]);
-                new PatchContainer([
+            ]);
+            new PatchContainer([
                 new Patcher("amdaemon.exe", "2.10.00", [
                     {
                         name: "Allow 127.0.0.1/localhost as the network server",
@@ -135,24 +136,26 @@
                         name: "Free Play",
                         tooltip: "Endless credits",
                         patches: [
-                            {offset: 0x2BB928, off: [0x28], on: [0x08]},
+                            { offset: 0x2BB928, off: [0x28], on: [0x08] },
                         ]
                     },
                     {
                         name: "Replace error 6401 with no error",
                         danger: "[DEPRECATED] Sets all instances of error 6401 to 0",
                         patches: [
-                            {offset: 0x2220F6, off: [0x01, 0x19], on: [0x00, 0x00]},
-                            {offset: 0x22229E, off: [0x01, 0x19], on: [0x00, 0x00]},
-                            {offset: 0x222C87, off: [0x01, 0x19], on: [0x00, 0x00]},
+                            { offset: 0x2220F6, off: [0x01, 0x19], on: [0x00, 0x00] },
+                            { offset: 0x22229E, off: [0x01, 0x19], on: [0x00, 0x00] },
+                            { offset: 0x222C87, off: [0x01, 0x19], on: [0x00, 0x00] },
                         ],
                     },
                 ])
-                ]);
-            });
-        </script>
-    </head>
-    <body>
-        <h1>CHUNITHM SUN Modder</h1>
-    </body>
+            ]);
+        });
+    </script>
+</head>
+
+<body>
+    <h1>CHUNITHM SUN Modder</h1>
+</body>
+
 </html>

--- a/chusansunplus.html
+++ b/chusansunplus.html
@@ -1,120 +1,121 @@
 <!DOCTYPE html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <title>CHUNITHM SUN PLUS Modder</title>
-        <link rel="stylesheet" href="css/style.css">
-        <script type="text/javascript" src="js/dllpatcher.js"></script>
-        <script type="text/javascript">
-            window.addEventListener("load", function () {
+
+<head>
+    <meta charset="utf-8">
+    <title>CHUNITHM SUN PLUS Modder</title>
+    <link rel="stylesheet" href="css/style.css">
+    <script type="text/javascript" src="js/dllpatcher.js"></script>
+    <script type="text/javascript">
+        window.addEventListener("load", function () {
             new PatchContainer([
                 new Patcher("chusanApp.exe", "2.16.00", [
                     {
                         name: "Disable shop close lockout",
                         tooltip: "Disables ~12-8am lockout. Does not disable maint lockout from 6:30-7am JST",
                         patches: [
-                            {offset: 0xBB74F3, off: [0x74], on: [0xEB]},
+                            { offset: 0xBB74F3, off: [0x74], on: [0xEB] },
                         ],
                     },
                     {
                         name: "Force shared audio mode, system audio samplerate must be 48000",
                         tooltip: "Improves compatibility but may increase latency",
                         patches: [
-                            {offset: 0xED689A, off: [0x01], on: [0x00]},
+                            { offset: 0xED689A, off: [0x01], on: [0x00] },
                         ],
                     },
                     {
                         name: "Force 2 channel audio output",
                         patches: [
-                            {offset: 0xED6971, off: [0x75, 0x3F], on: [0x90, 0x90]},
+                            { offset: 0xED6971, off: [0x75, 0x3F], on: [0x90, 0x90] },
                         ],
                     },
                     {
                         name: "Disable Song Select Timer",
                         patches: [
-                            {offset: 0x9B9B0B, off: [0x74], on: [0xEB]},
+                            { offset: 0x9B9B0B, off: [0x74], on: [0xEB] },
                         ],
                     },
                     {
                         name: "Set All Timers to 999",
                         patches: [
-                            {offset: 0x843800, off: [0x8B, 0x44, 0x24, 0x04, 0x69, 0xC0, 0xE8, 0x03, 0x00, 0x00], on: [0xB8, 0x58, 0x3E, 0x0F, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90]},
+                            { offset: 0x843800, off: [0x8B, 0x44, 0x24, 0x04, 0x69, 0xC0, 0xE8, 0x03, 0x00, 0x00], on: [0xB8, 0x58, 0x3E, 0x0F, 0x00, 0x90, 0x90, 0x90, 0x90, 0x90] },
                         ],
                     },
                     {
                         name: "Patch for head-to-head play",
                         tooltip: "Fix infinite sync while trying to connect to head to head play.",
                         patches: [
-                            {offset: 0x629263, off: [0x01], on: [0x00]},
+                            { offset: 0x629263, off: [0x01], on: [0x00] },
                         ]
                     },
                     {
                         name: "No Encryption",
                         tooltip: "Title server workaround",
                         patches: [
-                            {offset: 0x1D68450, off: [0xD2], on: [0x00]},
-                            {offset: 0x1D68454, off: [0xD2], on: [0x00]},
+                            { offset: 0x1D68450, off: [0xD2], on: [0x00] },
+                            { offset: 0x1D68454, off: [0xD2], on: [0x00] },
                         ]
                     },
                     {
                         name: "Unlimit Maximum Tracks",
                         tooltip: "You must check to play more than 7 tracks.",
                         patches: [
-                            {offset: 0x6F1D87, off: [0xF0], on: [0xC0]},
+                            { offset: 0x6F1D87, off: [0xF0], on: [0xC0] },
                         ],
                     },
                     {
-                        type : "number",
-                        name : "Max Tracks",
-                        offset : 0x397AE1,
-                        size : 4,
-                        min : 3,
-                        max : 12,
+                        type: "number",
+                        name: "Max Tracks",
+                        offset: 0x397AE1,
+                        size: 4,
+                        min: 3,
+                        max: 12,
                     },
                     {
                         name: "Ignore some errors from amdaemon",
                         danger: "[DEPRECATED] May relieve some errors like error 6401, but may also cause problems elsewhere.",
                         patches: [
-                            {offset: 0x37D6CB, off: [0x75], on: [0xEB]},
+                            { offset: 0x37D6CB, off: [0x75], on: [0xEB] },
                         ],
                     },
                     {
                         name: "CVT Mode",
                         danger: "[DEPRECATED] Check to use 60Hz",
                         patches: [
-                            {offset: 0x1CD04, off: [0x01], on: [0x00]},
-                            {offset: 0x1CD3B, off: [0x01], on: [0x00]},
+                            { offset: 0x1CD04, off: [0x01], on: [0x00] },
+                            { offset: 0x1CD3B, off: [0x01], on: [0x00] },
 
-                            {offset: 0x37B28B, off: [0x75], on: [0xEB]},
-                            {offset: 0x37CBEE, off: [0x84, 0xC0, 0x0F, 0x94, 0xC1], on: [0x90, 0x90, 0x90, 0x90, 0x90]},
-                            {offset: 0xEB9907, off: [0x80], on: [0x00]},
+                            { offset: 0x37B28B, off: [0x75], on: [0xEB] },
+                            { offset: 0x37CBEE, off: [0x84, 0xC0, 0x0F, 0x94, 0xC1], on: [0x90, 0x90, 0x90, 0x90, 0x90] },
+                            { offset: 0xEB9907, off: [0x80], on: [0x00] },
                         ],
                     },
                     {
                         name: "Disable 1080p check",
                         danger: "[DEPRECATED]",
                         patches: [
-                            {offset: 0x1CCBF, off: [0x81, 0xBC, 0x24, 0xB8, 0x02, 0x00, 0x00, 0x80, 0x07, 0x00, 0x00, 0x75, 0x1F, 0x81, 0xBC, 0x24, 0xBC, 0x02, 0x00, 0x00, 0x38, 0x04, 0x00, 0x00, 0x75, 0x12], on: [0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90]},
+                            { offset: 0x1CCBF, off: [0x81, 0xBC, 0x24, 0xB8, 0x02, 0x00, 0x00, 0x80, 0x07, 0x00, 0x00, 0x75, 0x1F, 0x81, 0xBC, 0x24, 0xBC, 0x02, 0x00, 0x00, 0x38, 0x04, 0x00, 0x00, 0x75, 0x12], on: [0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90] },
                         ],
                     },
                     {
                         name: "Bypass LED board check",
                         danger: "[DEPRECATED] Forces LED board check to good and auto continues",
                         patches: [
-                            {offset: 0x98BBAA, off: [0x01], on: [0x00]},
-                            {offset: 0x98BBAF, off: [0x00], on: [0x01]},
+                            { offset: 0x98BBAA, off: [0x01], on: [0x00] },
+                            { offset: 0x98BBAF, off: [0x00], on: [0x01] },
                         ]
                     },
                     {
                         name: "Force 120hz check",
                         danger: "[DEPRECATED] Check to make the 120hz check pass always (don't use this with the CVT Mode patch)",
                         patches: [
-                            {offset: 0x1CCB1, off: [0x85, 0xC0], on: [0xEB, 0x30]},
+                            { offset: 0x1CCB1, off: [0x85, 0xC0], on: [0xEB, 0x30] },
                         ],
                     },
                 ])
-                ]);
-                new PatchContainer([
+            ]);
+            new PatchContainer([
                 new Patcher("amdaemon.exe", "2.16.00", [
                     {
                         name: "Allow 127.0.0.1/localhost as the network server",
@@ -135,24 +136,26 @@
                         name: "Free Play",
                         tooltip: "Endless credits",
                         patches: [
-                            {offset: 0x2BB928, off: [0x28], on: [0x08]},
+                            { offset: 0x2BB928, off: [0x28], on: [0x08] },
                         ]
                     },
                     {
                         name: "Replace error 6401 with no error",
                         danger: "[DEPRECATED] Sets all instances of error 6401 to 0",
                         patches: [
-                            {offset: 0x2220F6, off: [0x01, 0x19], on: [0x00, 0x00]},
-                            {offset: 0x22229E, off: [0x01, 0x19], on: [0x00, 0x00]},
-                            {offset: 0x222C87, off: [0x01, 0x19], on: [0x00, 0x00]},
+                            { offset: 0x2220F6, off: [0x01, 0x19], on: [0x00, 0x00] },
+                            { offset: 0x22229E, off: [0x01, 0x19], on: [0x00, 0x00] },
+                            { offset: 0x222C87, off: [0x01, 0x19], on: [0x00, 0x00] },
                         ],
                     },
                 ])
-                ]);
-            });
-        </script>
-    </head>
-    <body>
-        <h1>CHUNITHM SUN PLUS Modder</h1>
-    </body>
+            ]);
+        });
+    </script>
+</head>
+
+<body>
+    <h1>CHUNITHM SUN PLUS Modder</h1>
+</body>
+
 </html>

--- a/chusansunplus.html
+++ b/chusansunplus.html
@@ -117,6 +117,28 @@
                 new PatchContainer([
                 new Patcher("amdaemon.exe", "2.16.00", [
                     {
+                        name: "Allow 127.0.0.1/localhost as the network server",
+                        patches: [
+                            {
+                                offset: 0x3B6EF4,
+                                off: [0xFF, 0x15, 0x3E, 0x79, 0x1A, 0x00, 0x8B],
+                                on: [0x33, 0xC0, 0x48, 0x83, 0xC4, 0x28, 0xC3],
+                            },
+                            {
+                                offset: 0x6BC83C,
+                                off: [0x31, 0x32, 0x37, 0x2F],
+                                on: [0x30, 0x2F, 0x38, 0x00],
+                            },
+                        ],
+                    },
+                    {
+                        name: "Free Play",
+                        tooltip: "Endless credits",
+                        patches: [
+                            {offset: 0x2BB928, off: [0x28], on: [0x08]},
+                        ]
+                    },
+                    {
                         name: "Replace error 6401 with no error",
                         danger: "[DEPRECATED] Sets all instances of error 6401 to 0",
                         patches: [


### PR DESCRIPTION
The first commit contains the actual changes, while the second commit is just formatting.

The patches added are:
- Allow 127.0.0.1/localhost as the network server
- Free play (infinite credits)

These patches were a pretty straightforward port from CHUNITHM pre-PARADISE, when amdaemon was built in to the game.

