### PR TITLE
Fix copying original bytes in dynamic patches

### DIFF
--- a/js/dllpatcher.js
+++ b/js/dllpatcher.js
@@ -210,8 +210,8 @@ class DynamicPatch {
                         replace(file, offset,
                             new TextEncoder().encode(featureOn? patch.on : patch.off));
                     } else {
-                        patch.on = patch.on.map((patch, idx) => patch === 'XX' ? file[offset + idx] : patch);
-                        patch.off = patch.off.map((patch, idx) => patch === 'XX' ? file[offset + idx] : patch);
+                        patch.on = patch.on.map((byte, idx) => byte === 'XX' ? file[offset + idx] : byte);
+                        patch.off = patch.off.map((byte, idx) => byte === 'XX' ? file[offset + idx] : byte);
                         replace(file, offset,
                             featureOn? patch.on : patch.off);
                     }
@@ -221,8 +221,8 @@ class DynamicPatch {
                     replace(file, patch.offset,
                         new TextEncoder().encode(featureOn? patch.on : patch.off));
                 } else {
-                    patch.on = patch.on.map((patch, idx) => patch === 'XX' ? file[patch.offset + idx] : patch);
-                    patch.off = patch.off.map((patch, idx) => patch === 'XX' ? file[patch.offset + idx] : patch);
+                    patch.on = patch.on.map((byte, idx) => byte === 'XX' ? file[patch.offset + idx] : byte);
+                    patch.off = patch.off.map((byte, idx) => byte === 'XX' ? file[patch.offset + idx] : byte);
                     replace(file, patch.offset,
                         featureOn? patch.on : patch.off);
                 }


### PR DESCRIPTION
Was originally going to make an issue for this but I ended up fixing it in the process. Original text detailing the bug below:

---

I think I've run into a bug with the output file when using dynamic patches. Here's one I wrote for the [INFINITAS launcher](https://d1rc4pwxnc0pe0.cloudfront.net/v3/resource/distribution/jp/2024031300/launcher/modules/bm2dx_launcher.exe):

```javascript
{
    type: 'dynamic',
    name: 'Bypass Game File Validation',
    tooltip: 'Ignore expected SHA-256 from server, allowing the game to launch with a modified executable',
    patches: [
        {
            off: [0x74, 'XX', 0xB9, 'XX', 'XX', 'XX', 'XX', 0xE8, 'XX', 'XX', 'XX', 'XX', 0x48, 0x8B, 0x7D],
            on: [0xEB, 'XX', 0xB9, 'XX', 'XX', 'XX', 'XX', 0xE8, 'XX', 'XX', 'XX', 'XX', 0x48, 0x8B, 0x7D],
        },
    ],
},
```

I'm only replacing the first byte, so the rest is just there to make it sufficiently unique. I kept the wildcards in the `on` patch as `XX` assuming it would only change the first byte and leave the rest untouched.

After enabling the patch and saving the file, the output was a little different to what I expected.

It seems like the wildcard bytes are getting replaced with `00` instead of the original contents:

![WinMergeU_C1xZ5dc1d4](https://github.com/mon/BemaniPatcher/assets/147343/5b655852-f066-45f6-9e2c-bc19c768bdc6)