### PR TITLE
GITADORA FUZZ-UP: Add warning about scores not saving

### DIFF
--- a/gitadorafuzzup.html
+++ b/gitadorafuzzup.html
@@ -15,12 +15,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x107E70, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAB2,
                         patches : [
                             {
@@ -80,6 +81,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAFA,
                         patches : [
                             {
@@ -174,12 +176,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x10B920, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAB1,
                         patches : [
                             {
@@ -239,6 +242,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAF7,
                         patches : [
                             {
@@ -333,12 +337,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x10DF80, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAB1,
                         patches : [
                             {
@@ -398,6 +403,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAF7,
                         patches : [
                             {
@@ -492,12 +498,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x10E250, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAB1,
                         patches : [
                             {
@@ -557,6 +564,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAF7,
                         patches : [
                             {
@@ -651,12 +659,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x10E800, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAB1,
                         patches : [
                             {
@@ -716,6 +725,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAF7,
                         patches : [
                             {
@@ -810,12 +820,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x10F850, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAB1,
                         patches : [
                             {
@@ -875,6 +886,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAF7,
                         patches : [
                             {
@@ -969,12 +981,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x10FD10, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAB1,
                         patches : [
                             {
@@ -1034,6 +1047,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AAF7,
                         patches : [
                             {
@@ -1128,12 +1142,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x10FDD0, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AB82,
                         patches : [
                             {
@@ -1193,6 +1208,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1ABCC,
                         patches : [
                             {
@@ -1287,12 +1303,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x110100, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AB82,
                         patches : [
                             {
@@ -1352,6 +1369,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1ABCC,
                         patches : [
                             {
@@ -1446,12 +1464,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x110130, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1AB82,
                         patches : [
                             {
@@ -1511,6 +1530,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1ABCC,
                         patches : [
                             {
@@ -1605,12 +1625,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x110170, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1B11F,
                         patches : [
                             {
@@ -1670,6 +1691,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1B169,
                         patches : [
                             {
@@ -1764,12 +1786,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x111DB0, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1B16F,
                         patches : [
                             {
@@ -1829,6 +1852,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1B1B9,
                         patches : [
                             {
@@ -1923,12 +1947,13 @@
                     },
                     {
                         name: "Premium Timer Freeze",
-                        danger: "Score saving may break",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs.",
                         patches: [{ offset: 0x112070, off: [0xFF, 0xC9], on: [0x90, 0x90] }],
                     },
                     {
                         type : "union",
                         name : "Premium Time 15",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1B16F,
                         patches : [
                             {
@@ -1988,6 +2013,7 @@
                     {
                         type : "union",
                         name : "Premium Time 10",
+                        danger: "Scores will only save on exiting Premium Time, and only up to 20 songs. Recommended to keep this under 45 minutes.",
                         offset : 0x1B1B9,
                         patches : [
                             {


### PR DESCRIPTION
Add big warnings to warn about scores not saving if PFree patches are not used properly.