### PR TITLE
Chusan: add a patch that removes recent scores from rating calculation

### DIFF
--- a/chusansunplus.html
+++ b/chusansunplus.html
@@ -73,6 +73,15 @@
                         max: 12,
                     },
                     {
+                        name: "Remove recent scores from rating calculation",
+                        tooltip: "Changes the rating algorithm from (Best30+Recent10)÷40 to (Best30)÷30",
+                        danger: "Decreases the rating ceiling",
+                        patches: [
+                            { offset: 0x6FF272, off: [0x0a], on: [0x00] },
+                            { offset: 0x6FF285, off: [0x28], on: [0x1e] },
+                        ],
+                    },
+                    {
                         name: "Ignore some errors from amdaemon",
                         danger: "[DEPRECATED] May relieve some errors like error 6401, but may also cause problems elsewhere.",
                         patches: [


### PR DESCRIPTION
This patch effectively removes R10.

### Motivation 

The in-game rating in Chunithm is calculated roughly as follows (in pseudocode):

```
let r = 0
for s in best_scores.take(30):
    r += s
for s in recent_30_scores.sort().take(10):
    r += s
r /= 40
```

The general consensus is that taking recent scores into account defeats the purpose of the overall rating as a skill/progress tracker; they can deflate it from 16.x to 14.x when you're all-playing easier charts, or they can artificially inflate it when you spam your best chart a dozen times. Some people choose to hide the in-game rating specifically for this reason.

### The patch

`0x6FF272` is the number of recent scores taken (10->0)
`0x6FF285` is the divisor (40->30)

The resulting value matches with a third-party score tracker that specifically only uses Best30.

### Disclaimers
* "... or they can artificially inflate it when you spam your best chart", so yes, the ceiling becomes lower which can matter if you're pushing for a landmark rating (16.0/16.5/17.0).
* This is a client-side change (and it works immediately after login), but the server does see it after a finished credit. This probably doesn't matter but I'd still rather mention it.'
* I haven't tested whether it's reversible, but I don't see why it shouldn't. I'm not actually altering the recents queue, only the procedure that calculates the overall rating.
* I made this and I'm ok with it being public. 
  * At the same time I understand if it doesn't get merged, since it's a behavioral patch rather than a technical one.


