### PR TITLE
Fix missing LEGGENDARIA folder charts on non-003 RESIDENT

### DIFF
--- a/iidx30resident.html
+++ b/iidx30resident.html
@@ -764,6 +764,7 @@
                     {
                         name: "Omnimix",
                         patches: [
+                            { offset: 0x591854, off: [0x74, 0x25], on: [0x90, 0x90] },
                             { offset: 0x662A20, off: [0x74, 0x73], on: [0xEB, 0x30] },
                             { offset: 0x662A55, off: [0x41], on: [0x58] },
                             { offset: 0x6650EF, off: [0x74], on: [0xEB] },
@@ -1152,6 +1153,7 @@
                     {
                         name: "Omnimix",
                         patches: [
+                            { offset: 0x4C4634, off: [0x74, 0x25], on: [0x90, 0x90] },
                             { offset: 0x595A10, off: [0x74, 0x73], on: [0xEB, 0x30] },
                             { offset: 0x595A45, off: [0x41], on: [0x58] },
                             { offset: 0x5980DF, off: [0x74], on: [0xEB] },


### PR DESCRIPTION
Ports over a missing patch from 003 to fix Omnimix charts not appearing in the folder

| Before  | After |
| -------- | ----- |
| ![20240925_1](https://github.com/user-attachments/assets/6fbc4c7d-31eb-40aa-948e-63cd896c3e16) | ![20240925_0](https://github.com/user-attachments/assets/95e90128-4966-4e0c-bf9a-3391fa7ad617) |
