### PR TITLE
[BST] Forced windowed mode + shorter monitor for BST1

### DIFF
--- a/beatstream1.html
+++ b/beatstream1.html
@@ -22,6 +22,42 @@
                                 on: [0xBB, 0x00, 0x00, 0x00, 0x00, 0xE9, 0xAE, 0x01, 0x00, 0x00]
                             }]
                         },
+						{
+                            name: "Shorter Monitor Check",
+                            patches: [
+                                {
+                                    offset: 0x1D760E,
+                                    off: [0x1E],
+                                    on: [0x03]
+                                }
+                            ]
+                        },
+						{
+                            name: "Force windowed mode", //Created by HiLord
+                            tooltip: "Makes the game launch in windowed mode *with both screens* as separate windows",
+                            patches: [
+                                {
+                                    offset: 0x1DB194,
+                                    off: [0x74],
+                                    on: [0xEB]
+                                },
+                                {
+                                    offset: 0x1DB626,
+                                    off: [0x74],
+                                    on: [0x75]
+                                },
+                                {
+                                    offset: 0x1DB6E5,
+                                    off: [0x75],
+                                    on: [0xEB]
+                                },
+                                {
+                                    offset: 0x1DD092,
+                                    off: [0x94],
+                                    on: [0x95]
+                                }
+                            ]
+                        },
                     ]),
                 ]);
             });

--- a/beatstream2.html
+++ b/beatstream2.html
@@ -31,7 +31,7 @@
                             }]
                         },
                         {
-                            name: "Increase hi-speed range to 1.0-2.5",
+                            name: "Change Hi-Speed range to 1.0 ~ 2.5",
                             patches: [
                                 {
                                     offset: 0xA36AA0, //Packed single-precision floats
@@ -110,7 +110,33 @@
                                     on: [0xE8, 0x67, 0xC5, 0xE1, 0xFF, 0x83, 0xB8, 0x8C, 0x01, 0x00, 0x00, 0x01, 0x75, 0x43, 0xC6, 0x87, 0x80, 0x00, 0x00, 0x00, 0x01, 0xEB, 0x3A, 0x90]
                                 }
                             ]
-                        }
+                        },
+						{
+                            name: "Force windowed mode", //Created by HiLord
+                            tooltip: "Makes the game launch in windowed mode *with both screens* as separate windows",
+                            patches: [
+                                {
+                                    offset: 0x1DA014,
+                                    off: [0x74],
+                                    on: [0xEB]
+                                },
+                                {
+                                    offset: 0x1DA443,
+                                    off: [0x74],
+                                    on: [0x75]
+                                },
+                                {
+                                    offset: 0x1DA4F6,
+                                    off: [0x75],
+                                    on: [0xEB]
+                                },
+                                {
+                                    offset: 0x1DB94F,
+                                    off: [0x94],
+                                    on: [0x95]
+                                }
+                            ]
+                        },
                     ]),
                 ]);
             });


### PR DESCRIPTION
Added the patch to force windowed mode with both screens working for both BeatStream and Animtribe, backported shorter monitor check from AT to BST1 and adjusted the phrasing for hi-speed patch a bit.